### PR TITLE
Fix crash when completing order without an active customer

### DIFF
--- a/cli/command_line_functions.py
+++ b/cli/command_line_functions.py
@@ -136,7 +136,11 @@ def complete_order_cli():
     #in order to apply a payment type to a customer's order,
     #we need a customer_id and the order_id of that customer's open order
     customer_id = get_active_customer()
-    open_order_id = get_customer_open_order(customer_id)
+    try:
+        open_order_id = get_customer_open_order(customer_id)
+    except:
+        print('Please activate a Customer.')
+        pass
 
     #check for active customer. if none, prompt user to activate a customer.
     if customer_id == None:


### PR DESCRIPTION
# Fix to prevent crash

## Status
Ready

## Description
This pull request fixes a problem when the user attempts to "Complete an Order" without setting a customer active. This fix requires the user to set a Customer as active before attempting to complete an order.

## Related Tickets 
[https://github.com/illegal-llamas/Bangazon_cli/pull/41](https://github.com/illegal-llamas/Bangazon_cli/pull/41)

## Impacted Areas of the Application
```
    cli/command_line_functions.py
```

## Deploy Notes
For example: 
```
    git pull 
    git fetch --all
    git checkout jn-bugfix
    cd cli
    python run.py
    Choose option 5, it will no longer crash even if a customer is not active.
```